### PR TITLE
feat: self signed certificates on TelemAgent

### DIFF
--- a/c.out
+++ b/c.out
@@ -1,0 +1,1 @@
+mode: set

--- a/c.out
+++ b/c.out
@@ -1,1 +1,0 @@
-mode: set

--- a/client/telemagent.go
+++ b/client/telemagent.go
@@ -30,7 +30,6 @@ import (
 	"time"
 )
 
-
 func (c *Client) DeviceSession() (deviceSession []string, err error) {
 	_, err = c.doSync("GET", "/v2/devicesession", nil, nil, nil, &deviceSession)
 
@@ -69,16 +68,15 @@ func (c *Client) Associate(email string, password string, otp string, isLogged b
 		if err != nil {
 			return err
 		}
-		
+
 		if !isEmailOk {
 			return errors.New("email or password are incorrect")
 		}
 	}
 
-
 	var payload struct {
-		Email     string `json:"email"`
-		Macaroon  string  `json:"macaroon"`
+		Email    string `json:"email"`
+		Macaroon string `json:"macaroon"`
 	}
 
 	macaroon, err := c.DeviceSession()
@@ -90,31 +88,30 @@ func (c *Client) Associate(email string, password string, otp string, isLogged b
 	payload.Email = email
 
 	jsonBytes, err := json.Marshal(payload)
-		if err != nil {
+	if err != nil {
 		return err
 	}
 
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonBytes))
-    req.Header.Set("Content-Type", "application/json")
-	if err != nil {
-        return err
-    }
-
-    client := &http.Client{
-		Timeout: 10 * time.Second,
-	}
-    resp, err := client.Do(req)
-    if err != nil {
-        return err
-    }
-    defer resp.Body.Close()
-
-	
-    body, err := io.ReadAll(resp.Body)
+	req.Header.Set("Content-Type", "application/json")
 	if err != nil {
 		return err
-    }
-	
+	}
+
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("could not associate device: %s", string(body))
 	}

--- a/cmd/snap/cmd_telemagent.go
+++ b/cmd/snap/cmd_telemagent.go
@@ -56,7 +56,7 @@ func init() {
 			name: i18n.G("<email>"),
 			// TRANSLATORS: This should not start with a lowercase letter (unless it's "login.ubuntu.com")
 			desc: i18n.G("The login.ubuntu.com email to login as"),
-		},})
+		}})
 }
 
 func associateDeviceWith2faRetry(cli *client.Client, email, password string) error {
@@ -111,11 +111,11 @@ func (x *cmdTelemAgent) Execute(args []string) error {
 	}
 
 	if email == "" {
-		
+
 		//TRANSLATORS: after the "... at" follows a URL in the next line
 		fmt.Fprint(Stdout, i18n.G("Personal information is handled as per our privacy notice at\n"))
 		fmt.Fprint(Stdout, "https://www.ubuntu.com/legal/dataprivacy/snap-store\n\n")
-		
+
 		email = x.Positional.Email
 		if email == "" {
 			fmt.Fprint(Stdout, i18n.G("Email address: "))
@@ -130,8 +130,6 @@ func (x *cmdTelemAgent) Execute(args []string) error {
 	} else {
 		err = x.client.Associate(email, "", "", true)
 	}
-
-
 
 	if err != nil {
 		return err

--- a/cmd/snapd/main.go
+++ b/cmd/snapd/main.go
@@ -62,7 +62,6 @@ func main() {
 		os.Exit(1)
 	}
 
-
 	// TODO look into signal.NotifyContext
 	ch := make(chan os.Signal, 2)
 	signal.Notify(ch, syscall.SIGINT, syscall.SIGTERM)
@@ -166,7 +165,7 @@ func run(ch chan os.Signal) error {
 		logger.Debug("Starting TelemAgent")
 		telemagent()
 	}()
-	
+
 out:
 	for {
 		select {

--- a/cmd/snapd/telemagent.go
+++ b/cmd/snapd/telemagent.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-<<<<<<< HEAD
-=======
 	"bytes"
 	"crypto/rand"
 	"crypto/rsa"
@@ -10,7 +8,6 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"errors"
->>>>>>> fb2c88504c (feat: update github lib)
 	"log"
 	"log/slog"
 	"math/big"
@@ -20,16 +17,10 @@ import (
 	"syscall"
 	"time"
 
-<<<<<<< HEAD
-	"github.com/snapcore/snapd/telemagent/pkg/hooks"
-
-	"github.com/caarlos0/env/v11"
-=======
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/telemagent/pkg/hooks"
 	mptls "github.com/snapcore/snapd/telemagent/pkg/tls"
 
->>>>>>> fb2c88504c (feat: update github lib)
 	mochi "github.com/mochi-mqtt/server/v2"
 	"github.com/mochi-mqtt/server/v2/listeners"
 )
@@ -59,11 +50,7 @@ func telemagent() {
 	})
 
 	// rest HTTP server Configuration
-<<<<<<< HEAD
-	serverConfig, err := hooks.NewConfig(env.Options{Prefix: mqttPrefix})
-=======
 	serverConfig, err := buildConfig()
->>>>>>> fb2c88504c (feat: update github lib)
 	if err != nil {
 		panic(err)
 	}
@@ -71,11 +58,8 @@ func telemagent() {
 	// Create logger with custom handler
 	logger := slog.New(logHandler)
 
-<<<<<<< HEAD
-=======
 	// addEnv(logger)
 
->>>>>>> fb2c88504c (feat: update github lib)
 	// Create the new MQTT Server.
 	server := mochi.New(&mochi.Options{
 		Logger:       logger,
@@ -85,11 +69,7 @@ func telemagent() {
 	// Allow all connections.
 	err = server.AddHook(new(hooks.TelemAgentHook), &hooks.TelemAgentHookOptions{
 		Server: server,
-<<<<<<< HEAD
-		Cfg:    serverConfig,
-=======
 		Cfg:    *serverConfig,
->>>>>>> fb2c88504c (feat: update github lib)
 	})
 
 	if err != nil {
@@ -97,15 +77,11 @@ func telemagent() {
 	}
 
 	// Create a TCP listener on a standard port.
-<<<<<<< HEAD
-	tcp := listeners.NewTCP(listeners.Config{ID: "t1", Address: serverConfig.BrokerPort})
-=======
 	tcp := listeners.NewTCP(listeners.Config{
 		ID:        "t1",
 		Address:   serverConfig.BrokerPort,
 		TLSConfig: serverConfig.TLSConfig,
 	})
->>>>>>> fb2c88504c (feat: update github lib)
 	err = server.AddListener(tcp)
 	if err != nil {
 		log.Fatal(err)
@@ -122,13 +98,6 @@ func telemagent() {
 	<-done
 
 	// Cleanup
-<<<<<<< HEAD
-}
-
-func addEnv() {
-	os.Setenv("MQTT_ENDPOINT", "mqtt://demo.staging:1883")
-	os.Setenv("MQTT_BROKER_PORT", ":1885")
-=======
 }
 
 func addEnv(logger *slog.Logger) {
@@ -347,5 +316,4 @@ func buildConfig() (*hooks.Config, error) {
 	}
 
 	return &cfg, nil
->>>>>>> fb2c88504c (feat: update github lib)
 }

--- a/cmd/snapd/telemagent.go
+++ b/cmd/snapd/telemagent.go
@@ -1,15 +1,35 @@
 package main
 
 import (
+<<<<<<< HEAD
+=======
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+>>>>>>> fb2c88504c (feat: update github lib)
 	"log"
 	"log/slog"
+	"math/big"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
+	"time"
 
+<<<<<<< HEAD
 	"github.com/snapcore/snapd/telemagent/pkg/hooks"
 
 	"github.com/caarlos0/env/v11"
+=======
+	"github.com/snapcore/snapd/client"
+	"github.com/snapcore/snapd/telemagent/pkg/hooks"
+	mptls "github.com/snapcore/snapd/telemagent/pkg/tls"
+
+>>>>>>> fb2c88504c (feat: update github lib)
 	mochi "github.com/mochi-mqtt/server/v2"
 	"github.com/mochi-mqtt/server/v2/listeners"
 )
@@ -17,7 +37,6 @@ import (
 const mqttPrefix = "MQTT_"
 
 func telemagent() {
-	addEnv()
 
 	// Create signals channel to run server until interrupted
 	sigs := make(chan os.Signal, 1)
@@ -40,7 +59,11 @@ func telemagent() {
 	})
 
 	// rest HTTP server Configuration
+<<<<<<< HEAD
 	serverConfig, err := hooks.NewConfig(env.Options{Prefix: mqttPrefix})
+=======
+	serverConfig, err := buildConfig()
+>>>>>>> fb2c88504c (feat: update github lib)
 	if err != nil {
 		panic(err)
 	}
@@ -48,6 +71,11 @@ func telemagent() {
 	// Create logger with custom handler
 	logger := slog.New(logHandler)
 
+<<<<<<< HEAD
+=======
+	// addEnv(logger)
+
+>>>>>>> fb2c88504c (feat: update github lib)
 	// Create the new MQTT Server.
 	server := mochi.New(&mochi.Options{
 		Logger:       logger,
@@ -57,7 +85,11 @@ func telemagent() {
 	// Allow all connections.
 	err = server.AddHook(new(hooks.TelemAgentHook), &hooks.TelemAgentHookOptions{
 		Server: server,
+<<<<<<< HEAD
 		Cfg:    serverConfig,
+=======
+		Cfg:    *serverConfig,
+>>>>>>> fb2c88504c (feat: update github lib)
 	})
 
 	if err != nil {
@@ -65,7 +97,15 @@ func telemagent() {
 	}
 
 	// Create a TCP listener on a standard port.
+<<<<<<< HEAD
 	tcp := listeners.NewTCP(listeners.Config{ID: "t1", Address: serverConfig.BrokerPort})
+=======
+	tcp := listeners.NewTCP(listeners.Config{
+		ID:        "t1",
+		Address:   serverConfig.BrokerPort,
+		TLSConfig: serverConfig.TLSConfig,
+	})
+>>>>>>> fb2c88504c (feat: update github lib)
 	err = server.AddListener(tcp)
 	if err != nil {
 		log.Fatal(err)
@@ -82,9 +122,230 @@ func telemagent() {
 	<-done
 
 	// Cleanup
+<<<<<<< HEAD
 }
 
 func addEnv() {
 	os.Setenv("MQTT_ENDPOINT", "mqtt://demo.staging:1883")
 	os.Setenv("MQTT_BROKER_PORT", ":1885")
+=======
+}
+
+func addEnv(logger *slog.Logger) {
+
+	snapClient := client.New(nil)
+
+	if os.Getenv("MQTT_ENDPOINT") == "" {
+		logger.Info("config was empty")
+		os.Setenv("MQTT_ENDPOINT", "mqtt://demo.staging:1883")
+
+		_, err := snapClient.SetConf("system", map[string]any{"telemagent.endpoint": "mqtt://demo.staging:1883"})
+		if err != nil {
+			logger.Error(err.Error())
+		}
+	}
+
+	if os.Getenv("MQTT_BROKER_PORT") == "" {
+		os.Setenv("MQTT_BROKER_PORT", ":1885")
+
+		_, err := snapClient.SetConf("system", map[string]any{"telemagent.port": ":1885"})
+		if err != nil {
+			logger.Error(err.Error())
+		}
+	}
+
+	if os.Getenv("MQTT_SERVER_CA_FILE") == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			logger.Error(err.Error())
+		}
+		sslDir := filepath.Join(home, ".ssl")
+
+		certFile, serverCAFile, keyFile, err := generateCertificates(sslDir)
+		if err != nil {
+			logger.Error(err.Error())
+		}
+		os.Setenv("MQTT_CERT_FILE", certFile)
+		os.Setenv("MQTT_KEY_FILE", keyFile)
+		os.Setenv("MQTT_SERVER_CA_FILE", serverCAFile)
+
+		_, err = snapClient.SetConf("system", map[string]any{"telemagent.ca-cert": serverCAFile})
+		if err != nil {
+			logger.Error(err.Error())
+		}
+
+	}
+
+	logger.Info("loaded env vars")
+}
+
+func generateCertificates(outDir string) (string, string, string, error) {
+	// Create output directory if missing
+	err := os.MkdirAll(outDir, 0700) // user-only access
+	if err != nil {
+		return "", "", "", err
+	}
+
+	caKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return "", "", "", err
+	}
+	caTemplate := x509.Certificate{
+		SerialNumber: big.NewInt(2025),
+		Subject: pkix.Name{
+			Organization: []string{"Local CA"},
+			CommonName:   "Local MQTT Root CA",
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().AddDate(10, 0, 0),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+	}
+	caCertBytes, err := x509.CreateCertificate(rand.Reader, &caTemplate, &caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		return "", "", "", err
+	}
+	var caCertPEM bytes.Buffer
+	pem.Encode(&caCertPEM, &pem.Block{Type: "CERTIFICATE", Bytes: caCertBytes})
+
+	// Server Keypair and signing
+	serverKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return "", "", "", err
+	}
+	serverTemplate := x509.Certificate{
+		SerialNumber: big.NewInt(2048),
+		Subject: pkix.Name{
+			Organization: []string{"telem-agent"},
+			CommonName:   "localhost",
+		},
+		NotBefore:   time.Now(),
+		NotAfter:    time.Now().AddDate(1, 0, 0),
+		KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:    []string{"localhost"},
+	}
+	serverCertBytes, err := x509.CreateCertificate(rand.Reader, &serverTemplate, &caTemplate, &serverKey.PublicKey, caKey)
+	if err != nil {
+		return "", "", "", err
+	}
+	var serverCertPEM bytes.Buffer
+	pem.Encode(&serverCertPEM, &pem.Block{Type: "CERTIFICATE", Bytes: serverCertBytes})
+
+	var serverKeyPEM bytes.Buffer
+	pem.Encode(&serverKeyPEM, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(serverKey)})
+
+	// Write to files
+	caPath := filepath.Join(outDir, "ca.crt")
+	certPath := filepath.Join(outDir, "cert.crt")
+	keyPath := filepath.Join(outDir, "key.crt")
+
+	err = os.WriteFile(caPath, caCertPEM.Bytes(), 0644)
+	if err != nil {
+		return "", "", "", err
+	}
+	err = os.WriteFile(certPath, serverCertPEM.Bytes(), 0644)
+	if err != nil {
+		return "", "", "", err
+	}
+	err = os.WriteFile(keyPath, serverKeyPEM.Bytes(), 0600) // key should be protected
+	if err != nil {
+		return "", "", "", err
+	}
+
+	return caPath, certPath, keyPath, nil
+}
+
+func buildConfig() (*hooks.Config, error) {
+	snapClient := client.New(nil)
+
+	var cfg hooks.Config
+
+	confs, err := snapClient.Conf("system", []string{"telemagent.endpoint"})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, conf := range confs {
+		confStr, ok := conf.(string)
+		if !ok {
+			return nil, errors.New("cannot convert to string")
+		}
+
+		if confStr == "" {
+			_, err := snapClient.SetConf("system", map[string]any{"telemagent.endpoint": "mqtt://demo.staging:1883"})
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		cfg.Endpoint = "mqtt://demo.staging:1883"
+	}
+
+	confs, err = snapClient.Conf("system", []string{"telemagent.port"})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, conf := range confs {
+		confStr, ok := conf.(string)
+		if !ok {
+			return nil, errors.New("cannot convert to string")
+		}
+
+		if confStr == "" {
+			_, err := snapClient.SetConf("system", map[string]any{"telemagent.port": ":1885"})
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		cfg.BrokerPort = ":1885"
+	}
+
+	confs, err = snapClient.Conf("system", []string{"telemagent.ca-cert"})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, conf := range confs {
+		confStr, ok := conf.(string)
+		if !ok {
+			return nil, errors.New("cannot convert to string")
+		}
+
+		if confStr == "" {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return nil, err
+			}
+			sslDir := filepath.Join(home, ".ssl")
+			certFile, serverCAFile, keyFile, err := generateCertificates(sslDir)
+			if err != nil {
+				return nil, err
+			}
+
+			_, err = snapClient.SetConf("system", map[string]any{"telemagent.ca-cert": serverCAFile})
+			if err != nil {
+				return nil, err
+			}
+
+			tlsCfg := mptls.Config{
+				CertFile:     certFile,
+				ServerCAFile: serverCAFile,
+				KeyFile:      keyFile,
+			}
+
+			cfg.TLSConfig, err = mptls.Load(&tlsCfg)
+			if err != nil {
+				return nil, err
+			}
+
+		}
+	}
+
+	return &cfg, nil
+>>>>>>> fb2c88504c (feat: update github lib)
 }

--- a/daemon/api_telemagent.go
+++ b/daemon/api_telemagent.go
@@ -29,12 +29,10 @@ import (
 var (
 	// see daemon.go:canAccess for details how the access is controlled
 	deviceSessionCmd = &Command{
-		Path:        "/v2/devicesession",
-		GET:         getDeviceSession,
-		ReadAccess:  openAccess{}, //TODO: this is open for now just for testing, but the goal is to make it protected
+		Path:       "/v2/devicesession",
+		GET:        getDeviceSession,
+		ReadAccess: openAccess{}, //TODO: this is open for now just for testing, but the goal is to make it protected
 	}
-
-
 )
 
 func getDeviceSession(c *Command, r *http.Request, user *auth.UserState) Response {
@@ -42,13 +40,11 @@ func getDeviceSession(c *Command, r *http.Request, user *auth.UserState) Respons
 	st := c.d.state
 	st.Lock()
 	defer st.Unlock()
-	
+
 	device, err := devicestatetest.Device(st)
 	if err != nil {
 		return SyncResponse(err)
 	}
 
-
 	return SyncResponse([]string{device.SessionMacaroon})
 }
-

--- a/overlord/configstate/configcore/runwithstate.go
+++ b/overlord/configstate/configcore/runwithstate.go
@@ -75,6 +75,9 @@ func init() {
 
 	// experimental.apparmor-prompting
 	addWithStateHandler(nil, doExperimentalApparmorPromptingDaemonRestart, nil)
+
+	// telemagent.ca-cert
+	addWithStateHandler(validateTelemAgentConf, handleTelemAgentConfiguration, nil)
 }
 
 // RunTransaction is an interface describing how to access

--- a/overlord/configstate/configcore/telemagent.go
+++ b/overlord/configstate/configcore/telemagent.go
@@ -1,0 +1,83 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+//go:build !nomanagers
+
+/*
+ * Copyright (C) 2017-2022 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package configcore
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"net/url"
+	"os"
+
+	"github.com/snapcore/snapd/overlord/restart"
+)
+
+func init() {
+	supportedConfigurations["core.telemagent.ca-cert"] = true
+	supportedConfigurations["core.telemagent.endpoint"] = true
+	supportedConfigurations["core.telemagent.port"] = true
+}
+
+func validateTelemAgentConf(tr RunTransaction) error {
+	// check cert
+	sslPath, err := coreCfg(tr, "telemagent.ca-cert")
+	if err != nil {
+		return err
+	}
+
+	data, err := os.ReadFile(sslPath)
+	if err != nil {
+		return err
+	}
+
+	block, _ := pem.Decode(data)
+	if block == nil || block.Type != "CERTIFICATE" {
+		return errors.New("not a PEM certificate")
+	}
+	_, err = x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return err
+	}
+
+	//check endpoint
+	endpoint, err := coreCfg(tr, "telemagent.endpoint")
+	if err != nil {
+		return err
+	}
+	_, err = url.Parse(endpoint)
+	if err != nil {
+		return err
+	}
+
+	return err
+}
+
+func handleTelemAgentConfiguration(tr RunTransaction, opts *fsOnlyContext) error {
+	st := tr.State()
+
+	st.Lock()
+	defer st.Unlock()
+
+	restartRequest(st, restart.RestartDaemon, nil)
+
+	return nil
+
+}

--- a/telemagent/pkg/hooks/connect.go
+++ b/telemagent/pkg/hooks/connect.go
@@ -24,11 +24,11 @@ const DeniedTopic = "DENIED"
 const ErrorTopic = "ERROR"
 
 type Config struct {
-	Enabled         bool   `env:"ENABLED"     envDefault:"false"`
-	Endpoint        string `env:"ENDPOINT"     envDefault:"mqtt://localhost:1883"`
-	ServerPort      int    `env:"PORT"     envDefault:"9090"`
-	BrokerPort		string `env:"BROKER_PORT" envDefault:":1884"`
-	TLSConfig *tls.Config
+	Enabled    bool   `env:"ENABLED"      envDefault:"false"`
+	Endpoint   string `env:"ENDPOINT"     envDefault:"mqtt://localhost:1883"`
+	ServerPort int    `env:"PORT"         envDefault:"9090"`
+	BrokerPort string `env:"BROKER_PORT"  envDefault:":1884"`
+	TLSConfig  *tls.Config
 }
 
 // Options contains configuration settings for the hook.
@@ -56,7 +56,7 @@ func NewConfig(opts env.Options) (Config, error) {
 		return Config{}, err
 	}
 
-	c.TLSConfig, err = mptls.LoadClient(&cfg)
+	c.TLSConfig, err = mptls.Load(&cfg)
 	if err != nil {
 		return Config{}, err
 	}
@@ -163,4 +163,3 @@ func (h *TelemAgentHook) OnConnectAuthenticate(cl *mochi.Client, pk packets.Pack
 
 	return true
 }
-

--- a/telemagent/pkg/hooks/send.go
+++ b/telemagent/pkg/hooks/send.go
@@ -1,20 +1,18 @@
 package hooks
 
 import (
-	"fmt"
 	"context"
 	"errors"
-	"strings"
+	"fmt"
 	"log/slog"
-
+	"strings"
 
 	"github.com/snapcore/snapd/telemagent/pkg/utils"
 
+	"github.com/canonical/mqtt.golang/paho"
 	mochi "github.com/mochi-mqtt/server/v2"
 	"github.com/mochi-mqtt/server/v2/packets"
-	"github.com/canonical/mqtt.golang/paho"
 	"github.com/snapcore/snapd/client"
-
 )
 
 func (h *TelemAgentHook) OnSubscribe(cl *mochi.Client, pk packets.Packet) packets.Packet {
@@ -163,8 +161,6 @@ func (h *TelemAgentHook) OnPacketEncode(cl *mochi.Client, pk packets.Packet) pac
 	return pk
 }
 
-
-
 func isAllowedTopic(snapClient *client.Client, topic, snapName, snapPublisher, action string) (bool, error) {
 	levels := strings.Split(topic, "/")[1:]
 	if len(levels) < 2 {
@@ -178,8 +174,6 @@ func isAllowedTopic(snapClient *client.Client, topic, snapName, snapPublisher, a
 	if action == "pub" {
 		return false, nil
 	}
-
-
 
 	return false, nil
 }

--- a/telemagent/pkg/hooks/setup.go
+++ b/telemagent/pkg/hooks/setup.go
@@ -3,10 +3,8 @@ package hooks
 import (
 	"context"
 
-
 	"github.com/canonical/mqtt.golang/autopaho"
 	"github.com/canonical/mqtt.golang/paho"
-
 )
 
 func (h *TelemAgentHook) OnStarted() {

--- a/telemagent/pkg/utils/utils.go
+++ b/telemagent/pkg/utils/utils.go
@@ -97,16 +97,14 @@ func GetDeviceId() (string, error) {
 	var results []asserts.Assertion
 	for i := 0; i < 5; i++ { // Initialization; Condition; Post-statement
 		results, err = snapClient.Known("serial", make(map[string]string), nil)
-	
 		if err == nil && len(results) != 0 {
 			break
 		} else {
 			time.Sleep(WAIT_TIME * time.Duration(math.Pow(2, float64(i))) * time.Millisecond)
 		}
 
-		
 	}
-	
+
 	if err != nil {
 		return "", err
 	} else if len(results) == 0 {


### PR DESCRIPTION
TelemAgent now exposes a TLS endpoint with a self-signed certificate. The certificate is created on snapd startup if it's not present. To get the path to the certificate, run `snap get system telemagent.ca-cert`. Further confgurations, the remote broker and the port exposed which can be retrieved and modified through `snap get/set`. 